### PR TITLE
Enable executing Graphene from StateViewer

### DIFF
--- a/src/lavit/stateviewer/StateNode.java
+++ b/src/lavit/stateviewer/StateNode.java
@@ -683,18 +683,6 @@ public class StateNode implements Shape {
 		return str;
 	}
 
-	public void runUnyo2(){
-		File f = new File("temp.lmn");
-		try {
-			FileWriter fp = new FileWriter(f);
-			fp.write(state);
-			fp.close();
-		} catch (IOException e) {
-			FrontEnd.printException(e);
-		}
-		(new LmntalRunner("-g "+Env.get("UNYO_OPTION"),f)).run();
-	}
-
 	public void runUnyo3()
 	{
 		File tempFile = new File("temp.lmn");

--- a/src/lavit/stateviewer/StateNode.java
+++ b/src/lavit/stateviewer/StateNode.java
@@ -712,6 +712,23 @@ public class StateNode implements Shape {
 		}
 	}
 
+	public void runGraphene()
+	{
+		File tempFile = new File("temp.lmn");
+		try
+		{
+			FileWriter writer = new FileWriter(tempFile);
+			writer.write(state);
+			writer.close();
+
+			FrontEnd.executeGraphene(tempFile);
+		}
+		catch (IOException e)
+		{
+			FrontEnd.printException(e);
+		}
+	}
+
 	boolean isMatch(String str){
 		if(dummy) return false;
 		if(childSet==null){

--- a/src/lavit/stateviewer/controller/StateRightMenu.java
+++ b/src/lavit/stateviewer/controller/StateRightMenu.java
@@ -67,7 +67,6 @@ public class StateRightMenu extends JPopupMenu implements ActionListener{
 
 	private JMenu nodeSubmenu = new JMenu("Node");
 	private JMenuItem remove = new JMenuItem("Remove");
-	private JMenuItem unyo2 = new JMenuItem("Unyo(2G)");
 	private JMenuItem unyo3 = new JMenuItem("Unyo(3G)");
 	private JMenuItem graphene = new JMenuItem("Graphene");
 	private JMenuItem add = new JMenuItem("add Editor");
@@ -90,9 +89,6 @@ public class StateRightMenu extends JPopupMenu implements ActionListener{
 
 		remove.addActionListener(this);
 		nodeSubmenu.add(remove);
-
-		unyo2.addActionListener(this);
-		nodeSubmenu.add(unyo2);
 
 		unyo3.addActionListener(this);
 		nodeSubmenu.add(unyo3);
@@ -150,10 +146,6 @@ public class StateRightMenu extends JPopupMenu implements ActionListener{
 			graphPanel.getDrawNodes().remove(graphPanel.getSelectNodes());
 			graphPanel.getSelectNodes().clear();
 			graphPanel.repaint();
-		}else if(src==unyo2){
-			for(StateNode node : graphPanel.getSelectNodes()){
-				node.runUnyo2();
-			}
 		}else if(src==unyo3){
 			for(StateNode node : graphPanel.getSelectNodes()){
 				node.runUnyo3();
@@ -185,7 +177,6 @@ public class StateRightMenu extends JPopupMenu implements ActionListener{
 
 	private void updateEnabled(){
 		remove.setEnabled(true);
-		unyo2.setEnabled(true);
 		unyo3.setEnabled(true);
 		graphene.setEnabled(true);
 		add.setEnabled(true);
@@ -203,7 +194,6 @@ public class StateRightMenu extends JPopupMenu implements ActionListener{
 			toNs.setEnabled(false);
 		}
 		if(graphPanel.getSelectNodes().size()!=1){
-			unyo2.setEnabled(false);
 			unyo3.setEnabled(false);
 			graphene.setEnabled(false);
 			add.setEnabled(false);

--- a/src/lavit/stateviewer/controller/StateRightMenu.java
+++ b/src/lavit/stateviewer/controller/StateRightMenu.java
@@ -69,6 +69,7 @@ public class StateRightMenu extends JPopupMenu implements ActionListener{
 	private JMenuItem remove = new JMenuItem("Remove");
 	private JMenuItem unyo2 = new JMenuItem("Unyo(2G)");
 	private JMenuItem unyo3 = new JMenuItem("Unyo(3G)");
+	private JMenuItem graphene = new JMenuItem("Graphene");
 	private JMenuItem add = new JMenuItem("add Editor");
 
 	private JMenu transitionSearchSubmenu = new JMenu("Transition Search");
@@ -95,6 +96,9 @@ public class StateRightMenu extends JPopupMenu implements ActionListener{
 
 		unyo3.addActionListener(this);
 		nodeSubmenu.add(unyo3);
+
+		graphene.addActionListener(this);
+		nodeSubmenu.add(graphene);
 
 		add.addActionListener(this);
 		nodeSubmenu.add(add);
@@ -154,6 +158,10 @@ public class StateRightMenu extends JPopupMenu implements ActionListener{
 			for(StateNode node : graphPanel.getSelectNodes()){
 				node.runUnyo3();
 			}
+		}else if(src==graphene){
+			for(StateNode node : graphPanel.getSelectNodes()){
+				node.runGraphene();
+			}
 		}else if(src==add){
 			for(StateNode node : graphPanel.getSelectNodes()){
 				FrontEnd.mainFrame.editorPanel.getSelectedEditor().replaceSelection(node.state);
@@ -179,6 +187,7 @@ public class StateRightMenu extends JPopupMenu implements ActionListener{
 		remove.setEnabled(true);
 		unyo2.setEnabled(true);
 		unyo3.setEnabled(true);
+		graphene.setEnabled(true);
 		add.setEnabled(true);
 
 		backNs.setEnabled(true);
@@ -196,6 +205,7 @@ public class StateRightMenu extends JPopupMenu implements ActionListener{
 		if(graphPanel.getSelectNodes().size()!=1){
 			unyo2.setEnabled(false);
 			unyo3.setEnabled(false);
+			graphene.setEnabled(false);
 			add.setEnabled(false);
 		}
 


### PR DESCRIPTION
Add "Graphene" option to right-click-menu in StateViewer.
Now we can use Graphene to inspect transition states, as well as UNYO(3G).