### PR TITLE
fix getLmnDocument

### DIFF
--- a/src/lavit/multiedit/coloring/LmnTextPane.java
+++ b/src/lavit/multiedit/coloring/LmnTextPane.java
@@ -208,24 +208,24 @@ public class LmnTextPane extends JTextPane
 
 	public LmnDocument getLMNDocument()
 	{
-    Document doc = getDocument();
+		Document doc = getDocument();
 
-    if(doc instanceof LmnDocument){
-      return (LmnDocument) doc;
-    }else {
-      LmnDocument lmndoc = new LmnDocument();
-      try {
-        lmndoc.initializeText(doc.getText(0, doc.getLength()));
-        // 0からdocのlengthまでを取ってるだけでBadLocationExceptionは起きないはずなので握り潰す
-      } catch (BadLocationException e){
-        System.err.println(e);
-      }
+		if(doc instanceof LmnDocument){
+			return (LmnDocument) doc;
+		}else {
+			LmnDocument lmndoc = new LmnDocument();
+			try {
+				lmndoc.initializeText(doc.getText(0, doc.getLength()));
+				// 0からdocのlengthまでを取ってるだけでBadLocationExceptionは起きないはずなので握り潰す
+			} catch (BadLocationException e){
+				System.err.println(e);
+			}
 
-      // なぜかハイライトがされなくなったのでLmnDocument.updateHighlight()をコピペ
-      lmndoc.setDirty(true);
-      lmndoc.reparse();
-      return lmndoc;
-    }
+			// なぜかハイライトがされなくなったのでLmnDocument.updateHighlight()をコピペ
+			lmndoc.setDirty(true);
+			lmndoc.reparse();
+			return lmndoc;
+		}
 	}
 
 	public void setTabWidth(int spaces)

--- a/src/lavit/multiedit/coloring/LmnTextPane.java
+++ b/src/lavit/multiedit/coloring/LmnTextPane.java
@@ -208,7 +208,24 @@ public class LmnTextPane extends JTextPane
 
 	public LmnDocument getLMNDocument()
 	{
-		return (LmnDocument)getDocument();
+    Document doc = getDocument();
+
+    if(doc instanceof LmnDocument){
+      return (LmnDocument) doc;
+    }else {
+      LmnDocument lmndoc = new LmnDocument();
+      try {
+        lmndoc.initializeText(doc.getText(0, doc.getLength()));
+        // 0からdocのlengthまでを取ってるだけでBadLocationExceptionは起きないはずなので握り潰す
+      } catch (BadLocationException e){
+        System.err.println(e);
+      }
+
+      // なぜかハイライトがされなくなったのでLmnDocument.updateHighlight()をコピペ
+      lmndoc.setDirty(true);
+      lmndoc.reparse();
+      return lmndoc;
+    }
 	}
 
 	public void setTabWidth(int spaces)


### PR DESCRIPTION
すでに開いているファイルを開き直したときに

[14:15:20] java.lang.ClassCastException: javax.swing.text.DefaultStyledDocument cannot be cast to lavit.multiedit.coloring.LmnDocument
...

のようなエラーが出るバグを修正した。
