### PR TITLE
fix bug about first.lmn

### DIFF
--- a/src/lavit/editor/EditorPanel.java
+++ b/src/lavit/editor/EditorPanel.java
@@ -318,7 +318,7 @@ public class EditorPanel extends JPanel implements CommonFontUser
 	 */
 	public void firstFileOpen()
 	{
-		File first = new File("first.lmn");
+		File first = new File("first.lmn").getAbsoluteFile();
 		if (!first.exists())
 		{
 			try


### PR DESCRIPTION
初回起動時に表示される「first.lmn」が正常にコンパイル・実行できない問題を修正

**Tips**: 多分以下のファイルを消去すれば、初回起動時の状態が再現できます。

- properties/*
- env.txt