### PR TITLE
fix comment logic/add bracket autocomplete

### DIFF
--- a/src/lavit/multiedit/coloring/LmnTextPane.java
+++ b/src/lavit/multiedit/coloring/LmnTextPane.java
@@ -130,32 +130,32 @@ public class LmnTextPane extends JTextPane
      */
     addKeyListener(new KeyAdapter()
     {
-      public void keyTyped(KeyEvent e)
-      {
-        char c = e.getKeyChar();
-        if (c == '(' || c == '{' || c == '[' || c == '"' || c == '\'')
+        public void keyTyped(KeyEvent e)
         {
-          LmnDocument doc = getLMNDocument();
-          int pos = getCaretPosition();
-          try
-          {
-            if (c == '"' || c == '\'')
+            char c = e.getKeyChar();
+            if (c == '(' || c == '{' || c == '[' || c == '"' || c == '\'')
             {
-              doc.insertString(pos, String.valueOf(c), null);
-              setCaretPosition(pos);
-            }
-            else
+            LmnDocument doc = getLMNDocument();
+            int pos = getCaretPosition();
+            try
             {
-              doc.insertString(pos, String.valueOf(getPairParenChar(c)), null);
-              setCaretPosition(pos);
+                if (c == '"' || c == '\'')
+                {
+                doc.insertString(pos, String.valueOf(c), null);
+                setCaretPosition(pos);
+                }
+                else
+                {
+                doc.insertString(pos, String.valueOf(getPairParenChar(c)), null);
+                setCaretPosition(pos);
+                }
             }
-          }
-          catch (BadLocationException ex)
-          {
-            ex.printStackTrace();
-          }
+            catch (BadLocationException ex)
+            {
+                ex.printStackTrace();
+            }
+            }
         }
-      }
     });
 
 		CustomCaret caret = new CustomCaret();
@@ -491,91 +491,92 @@ public class LmnTextPane extends JTextPane
 			end = endElem.getEndOffset() - 1;
 		}
 
-    try {
-      String text = getText(start, end - start);
-      boolean lastNewline = text.endsWith("\n");
-      String[] lines = text.split("\n");
-      String comment_par = "% ";
-      String comment_sl = "// ";
-      boolean commented = lines[0].startsWith(comment_par.substring(0, 2))
-          || lines[0].startsWith(comment_sl.substring(0, 3));
-      StringBuilder sb = new StringBuilder();
-      for (String line : lines)
-      {
-        if (commented)
+        try
         {
-          if (line.startsWith(comment_par.substring(0, 2)))
-          {
-            sb.append(line.substring(comment_par.length()));
-            int count = 0;
-            for (int i = 0; i < sb.length(); i++)
+        String text = getText(start, end - start);
+        boolean lastNewline = text.endsWith("\n");
+        String[] lines = text.split("\n");
+        String comment_par = "% ";
+        String comment_sl = "// ";
+        boolean commented = lines[0].startsWith(comment_par.substring(0, 2))
+            || lines[0].startsWith(comment_sl.substring(0, 3));
+        StringBuilder sb = new StringBuilder();
+        for (String line : lines)
+        {
+            if (commented)
             {
-              if (sb.charAt(i) == ' ' || sb.charAt(i) == '\t' || sb.charAt(i) == comment_par.charAt(0))
-              {
-                count++;
-              }
-              else
-              {
-                break;
-              }
+            if (line.startsWith(comment_par.substring(0, 2)))
+            {
+                sb.append(line.substring(comment_par.length()));
+                int count = 0;
+                for (int i = 0; i < sb.length(); i++)
+                {
+                if (sb.charAt(i) == ' ' || sb.charAt(i) == '\t' || sb.charAt(i) == comment_par.charAt(0))
+                {
+                    count++;
+                }
+                else
+                {
+                    break;
+                }
+                }
+                sb.delete(0, count);
             }
-            sb.delete(0, count);
-          }
-          else if (line.startsWith(comment_sl.substring(0, 3)))
-          {
-            sb.append(line.substring(comment_sl.length()));
-            int count = 0;
-            for (int i = 0; i < sb.length(); i++)
+            else if (line.startsWith(comment_sl.substring(0, 3)))
             {
-              if (sb.charAt(i) == ' ' || sb.charAt(i) == '\t' || sb.charAt(i) == comment_sl.charAt(0))
-              {
-                count++;
-              }
+                sb.append(line.substring(comment_sl.length()));
+                int count = 0;
+                for (int i = 0; i < sb.length(); i++)
+                {
+                if (sb.charAt(i) == ' ' || sb.charAt(i) == '\t' || sb.charAt(i) == comment_sl.charAt(0))
+                {
+                    count++;
+                }
 
-              else
-              {
-                break;
-              }
+                else
+                {
+                    break;
+                }
+                }
+                sb.delete(0, count);
             }
-            sb.delete(0, count);
-          }
-          else
-          {
+            else
+            {
+                sb.append(line);
+            }
+            }
+            else if (line.length() == 0 || isWhitespaces(line))
+            {
             sb.append(line);
-          }
+            }
+            else
+            {
+            sb.append(comment_sl).append(line);
+            }
+            sb.append("\n");
         }
-        else if (line.length() == 0 || isWhitespaces(line))
+
+        if (!lastNewline)
         {
-          sb.append(line);
+            sb.deleteCharAt(sb.length() - 1);
         }
-        else
+
+        doc.replace(start, end - start, sb.toString(), null);
+
+        new_start += 2 * (commented ? -1 : 1);
+        new_end += 2 * (lines.length) * (commented ? -1 : 1);
+
+        setSelectionStart(new_start);
+        setSelectionEnd(new_end);
+        }
+        catch (BadLocationException e)
         {
-          sb.append(comment_sl).append(line);
+        e.printStackTrace();
+        return false;
         }
-        sb.append("\n");
-      }
 
-      if (!lastNewline)
-      {
-        sb.deleteCharAt(sb.length() - 1);
-      }
-
-      doc.replace(start, end - start, sb.toString(), null);
-
-      new_start += 2 * (commented ? -1 : 1);
-      new_end += 2 * (lines.length) * (commented ? -1 : 1);
-
-      setSelectionStart(new_start);
-      setSelectionEnd(new_end);
+        return true;
     }
-    catch (BadLocationException e)
-    {
-      e.printStackTrace();
-      return false;
-    }
-
-    return true;
-  }
 
 	private boolean indent(int keyModifiers)
 	{

--- a/src/lavit/multiedit/coloring/LmnTextPane.java
+++ b/src/lavit/multiedit/coloring/LmnTextPane.java
@@ -125,6 +125,39 @@ public class LmnTextPane extends JTextPane
 			}
 		});
 
+    /*
+     * ペア括弧とクオーテーションの自動補完
+     */
+    addKeyListener(new KeyAdapter()
+    {
+      public void keyTyped(KeyEvent e)
+      {
+        char c = e.getKeyChar();
+        if (c == '(' || c == '{' || c == '[' || c == '"' || c == '\'')
+        {
+          LmnDocument doc = getLMNDocument();
+          int pos = getCaretPosition();
+          try
+          {
+            if (c == '"' || c == '\'')
+            {
+              doc.insertString(pos, String.valueOf(c), null);
+              setCaretPosition(pos);
+            }
+            else
+            {
+              doc.insertString(pos, String.valueOf(getPairParenChar(c)), null);
+              setCaretPosition(pos);
+            }
+          }
+          catch (BadLocationException ex)
+          {
+            ex.printStackTrace();
+          }
+        }
+      }
+    });
+
 		CustomCaret caret = new CustomCaret();
 		caret.setBlinkRate(getCaret().getBlinkRate());
 		setCaret(caret);
@@ -458,55 +491,68 @@ public class LmnTextPane extends JTextPane
 			end = endElem.getEndOffset() - 1;
 		}
 
-		try
-		{
-			String text = getText(start, end - start);
-			boolean lastNewline = text.endsWith("\n");
-			String[] lines = text.split("\n");
-			String comment = "//";
-			boolean commented = lines[0].startsWith(comment);
-			StringBuilder sb = new StringBuilder();
-			for (String line : lines)
-			{
-				if (commented)
-				{
-					if (line.startsWith(comment))
-					{
-						sb.append(line.substring(comment.length()));
-					}
-					else
-					{
-						sb.append(line);
-					}
-				}
-				else
-				{
-					sb.append(comment).append(line);
-				}
-				sb.append("\n");
-			}
+    try {
+      String text = getText(start, end - start);
+      boolean lastNewline = text.endsWith("\n");
+      String[] lines = text.split("\n");
+      String comment_par = "% ";
+      String comment_sl = "// ";
+      boolean commented = lines[0].startsWith(comment_par.substring(0, 2))
+          || lines[0].startsWith(comment_sl.substring(0, 3));
+      StringBuilder sb = new StringBuilder();
+      for (String line : lines) {
+        if (commented) {
+          if (line.startsWith(comment_par.substring(0, 2))) {
+            sb.append(line.substring(comment_par.length()));
+            int count = 0;
+            for (int i = 0; i < sb.length(); i++) {
+              if (sb.charAt(i) == ' ' || sb.charAt(i) == '\t' || sb.charAt(i) == comment_par.charAt(0)) {
+                count++;
+              } else {
+                break;
+              }
+            }
+            sb.delete(0, count);
+          } else if (line.startsWith(comment_sl.substring(0, 3))) {
+            sb.append(line.substring(comment_sl.length()));
+            int count = 0;
+            for (int i = 0; i < sb.length(); i++) {
+              if (sb.charAt(i) == ' ' || sb.charAt(i) == '\t' || sb.charAt(i) == comment_sl.charAt(0)) {
+                count++;
+              } else {
+                break;
+              }
+            }
+            sb.delete(0, count);
+          } else {
+            sb.append(line);
+          }
+        } else if (line.length() == 0 || isWhitespaces(line)) {
+          sb.append(line);
+        } else {
+          sb.append(comment_sl).append(line);
+        }
+        sb.append("\n");
+      }
 
-			if (!lastNewline)
-			{
-				sb.deleteCharAt(sb.length() - 1);
-			}
+      if (!lastNewline) {
+        sb.deleteCharAt(sb.length() - 1);
+      }
 
-			doc.replace(start, end - start, sb.toString(), null);
+      doc.replace(start, end - start, sb.toString(), null);
 
-			new_start += 2 * (commented ? -1 : 1);
-			new_end += 2 * (lines.length) * (commented ? -1 : 1);
+      new_start += 2 * (commented ? -1 : 1);
+      new_end += 2 * (lines.length) * (commented ? -1 : 1);
 
-			setSelectionStart(new_start);
-			setSelectionEnd(new_end);
-		}
-		catch (BadLocationException e)
-		{
-			e.printStackTrace();
-			return false;
-		}
+      setSelectionStart(new_start);
+      setSelectionEnd(new_end);
+    } catch (BadLocationException e) {
+      e.printStackTrace();
+      return false;
+    }
 
-		return true;
-	}
+    return true;
+  }
 
 	private boolean indent(int keyModifiers)
 	{
@@ -519,7 +565,7 @@ public class LmnTextPane extends JTextPane
 
 		// no selection, do nothing
 		if (start == end) return false;
-		
+
 		// fix up the selection to be line-based
 		int startLine = doc.getDefaultRootElement().getElementIndex(start);
 		int endLine = doc.getDefaultRootElement().getElementIndex(end);
@@ -570,7 +616,7 @@ public class LmnTextPane extends JTextPane
 			e.printStackTrace();
 			return false;
 		}
-		
+
 		return true;
 	}
 

--- a/src/lavit/multiedit/coloring/LmnTextPane.java
+++ b/src/lavit/multiedit/coloring/LmnTextPane.java
@@ -135,25 +135,25 @@ public class LmnTextPane extends JTextPane
             char c = e.getKeyChar();
             if (c == '(' || c == '{' || c == '[' || c == '"' || c == '\'')
             {
-            LmnDocument doc = getLMNDocument();
-            int pos = getCaretPosition();
-            try
-            {
-                if (c == '"' || c == '\'')
+                LmnDocument doc = getLMNDocument();
+                int pos = getCaretPosition();
+                try
                 {
-                doc.insertString(pos, String.valueOf(c), null);
-                setCaretPosition(pos);
+                    if (c == '"' || c == '\'')
+                    {
+                        doc.insertString(pos, String.valueOf(c), null);
+                        setCaretPosition(pos);
+                    }
+                    else
+                    {
+                        doc.insertString(pos, String.valueOf(getPairParenChar(c)), null);
+                        setCaretPosition(pos);
+                    }
                 }
-                else
+                catch (BadLocationException ex)
                 {
-                doc.insertString(pos, String.valueOf(getPairParenChar(c)), null);
-                setCaretPosition(pos);
+                    ex.printStackTrace();
                 }
-            }
-            catch (BadLocationException ex)
-            {
-                ex.printStackTrace();
-            }
             }
         }
     });
@@ -505,53 +505,52 @@ public class LmnTextPane extends JTextPane
             {
                 if (commented)
                 {
-                if (line.startsWith(comment_par.substring(0, 2)))
-                {
-                    sb.append(line.substring(comment_par.length()));
-                    int count = 0;
-                    for (int i = 0; i < sb.length(); i++)
+                    if (line.startsWith(comment_par.substring(0, 2)))
                     {
-                    if (sb.charAt(i) == ' ' || sb.charAt(i) == '\t' || sb.charAt(i) == comment_par.charAt(0))
+                        sb.append(line.substring(comment_par.length()));
+                        int count = 0;
+                        for (int i = 0; i < sb.length(); i++)
+                        {
+                            if (sb.charAt(i) == ' ' || sb.charAt(i) == '\t' || sb.charAt(i) == comment_par.charAt(0))
+                            {
+                                count++;
+                            }
+                            else
+                            {
+                                break;
+                            }
+                        }
+                        sb.delete(0, count);
+                    }
+                    else if (line.startsWith(comment_sl.substring(0, 3)))
                     {
-                        count++;
+                        sb.append(line.substring(comment_sl.length()));
+                        int count = 0;
+                        for (int i = 0; i < sb.length(); i++)
+                        {
+                            if (sb.charAt(i) == ' ' || sb.charAt(i) == '\t' || sb.charAt(i) == comment_sl.charAt(0))
+                            {
+                                count++;
+                            }
+                            else
+                            {
+                                break;
+                            }
+                        }
+                        sb.delete(0, count);
                     }
                     else
                     {
-                        break;
+                        sb.append(line);
                     }
-                    }
-                    sb.delete(0, count);
-                }
-                else if (line.startsWith(comment_sl.substring(0, 3)))
-                {
-                    sb.append(line.substring(comment_sl.length()));
-                    int count = 0;
-                    for (int i = 0; i < sb.length(); i++)
-                    {
-                    if (sb.charAt(i) == ' ' || sb.charAt(i) == '\t' || sb.charAt(i) == comment_sl.charAt(0))
-                    {
-                        count++;
-                    }
-
-                    else
-                    {
-                        break;
-                    }
-                    }
-                    sb.delete(0, count);
-                }
-                else
-                {
-                    sb.append(line);
-                }
                 }
                 else if (line.length() == 0 || isWhitespaces(line))
                 {
-                sb.append(line);
+                    sb.append(line);
                 }
                 else
                 {
-                sb.append(comment_sl).append(line);
+                    sb.append(comment_sl).append(line);
                 }
                 sb.append("\n");
             }

--- a/src/lavit/multiedit/coloring/LmnTextPane.java
+++ b/src/lavit/multiedit/coloring/LmnTextPane.java
@@ -493,86 +493,86 @@ public class LmnTextPane extends JTextPane
 
         try
         {
-        String text = getText(start, end - start);
-        boolean lastNewline = text.endsWith("\n");
-        String[] lines = text.split("\n");
-        String comment_par = "% ";
-        String comment_sl = "// ";
-        boolean commented = lines[0].startsWith(comment_par.substring(0, 2))
-            || lines[0].startsWith(comment_sl.substring(0, 3));
-        StringBuilder sb = new StringBuilder();
-        for (String line : lines)
-        {
-            if (commented)
+            String text = getText(start, end - start);
+            boolean lastNewline = text.endsWith("\n");
+            String[] lines = text.split("\n");
+            String comment_par = "% ";
+            String comment_sl = "// ";
+            boolean commented = lines[0].startsWith(comment_par.substring(0, 2))
+                || lines[0].startsWith(comment_sl.substring(0, 3));
+            StringBuilder sb = new StringBuilder();
+            for (String line : lines)
             {
-            if (line.startsWith(comment_par.substring(0, 2)))
-            {
-                sb.append(line.substring(comment_par.length()));
-                int count = 0;
-                for (int i = 0; i < sb.length(); i++)
+                if (commented)
                 {
-                if (sb.charAt(i) == ' ' || sb.charAt(i) == '\t' || sb.charAt(i) == comment_par.charAt(0))
+                if (line.startsWith(comment_par.substring(0, 2)))
                 {
-                    count++;
+                    sb.append(line.substring(comment_par.length()));
+                    int count = 0;
+                    for (int i = 0; i < sb.length(); i++)
+                    {
+                    if (sb.charAt(i) == ' ' || sb.charAt(i) == '\t' || sb.charAt(i) == comment_par.charAt(0))
+                    {
+                        count++;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                    }
+                    sb.delete(0, count);
                 }
-                else
+                else if (line.startsWith(comment_sl.substring(0, 3)))
                 {
-                    break;
-                }
-                }
-                sb.delete(0, count);
-            }
-            else if (line.startsWith(comment_sl.substring(0, 3)))
-            {
-                sb.append(line.substring(comment_sl.length()));
-                int count = 0;
-                for (int i = 0; i < sb.length(); i++)
-                {
-                if (sb.charAt(i) == ' ' || sb.charAt(i) == '\t' || sb.charAt(i) == comment_sl.charAt(0))
-                {
-                    count++;
-                }
+                    sb.append(line.substring(comment_sl.length()));
+                    int count = 0;
+                    for (int i = 0; i < sb.length(); i++)
+                    {
+                    if (sb.charAt(i) == ' ' || sb.charAt(i) == '\t' || sb.charAt(i) == comment_sl.charAt(0))
+                    {
+                        count++;
+                    }
 
+                    else
+                    {
+                        break;
+                    }
+                    }
+                    sb.delete(0, count);
+                }
                 else
                 {
-                    break;
+                    sb.append(line);
                 }
                 }
-                sb.delete(0, count);
-            }
-            else
-            {
+                else if (line.length() == 0 || isWhitespaces(line))
+                {
                 sb.append(line);
+                }
+                else
+                {
+                sb.append(comment_sl).append(line);
+                }
+                sb.append("\n");
             }
-            }
-            else if (line.length() == 0 || isWhitespaces(line))
+
+            if (!lastNewline)
             {
-            sb.append(line);
+                sb.deleteCharAt(sb.length() - 1);
             }
-            else
-            {
-            sb.append(comment_sl).append(line);
-            }
-            sb.append("\n");
-        }
 
-        if (!lastNewline)
-        {
-            sb.deleteCharAt(sb.length() - 1);
-        }
+            doc.replace(start, end - start, sb.toString(), null);
 
-        doc.replace(start, end - start, sb.toString(), null);
+            new_start += 2 * (commented ? -1 : 1);
+            new_end += 2 * (lines.length) * (commented ? -1 : 1);
 
-        new_start += 2 * (commented ? -1 : 1);
-        new_end += 2 * (lines.length) * (commented ? -1 : 1);
-
-        setSelectionStart(new_start);
-        setSelectionEnd(new_end);
+            setSelectionStart(new_start);
+            setSelectionEnd(new_end);
         }
         catch (BadLocationException e)
         {
-        e.printStackTrace();
-        return false;
+            e.printStackTrace();
+            return false;
         }
 
         return true;

--- a/src/lavit/multiedit/coloring/LmnTextPane.java
+++ b/src/lavit/multiedit/coloring/LmnTextPane.java
@@ -500,42 +500,63 @@ public class LmnTextPane extends JTextPane
       boolean commented = lines[0].startsWith(comment_par.substring(0, 2))
           || lines[0].startsWith(comment_sl.substring(0, 3));
       StringBuilder sb = new StringBuilder();
-      for (String line : lines) {
-        if (commented) {
-          if (line.startsWith(comment_par.substring(0, 2))) {
+      for (String line : lines)
+      {
+        if (commented)
+        {
+          if (line.startsWith(comment_par.substring(0, 2)))
+          {
             sb.append(line.substring(comment_par.length()));
             int count = 0;
-            for (int i = 0; i < sb.length(); i++) {
-              if (sb.charAt(i) == ' ' || sb.charAt(i) == '\t' || sb.charAt(i) == comment_par.charAt(0)) {
+            for (int i = 0; i < sb.length(); i++)
+            {
+              if (sb.charAt(i) == ' ' || sb.charAt(i) == '\t' || sb.charAt(i) == comment_par.charAt(0))
+              {
                 count++;
-              } else {
+              }
+              else
+              {
                 break;
               }
             }
             sb.delete(0, count);
-          } else if (line.startsWith(comment_sl.substring(0, 3))) {
+          }
+          else if (line.startsWith(comment_sl.substring(0, 3)))
+          {
             sb.append(line.substring(comment_sl.length()));
             int count = 0;
-            for (int i = 0; i < sb.length(); i++) {
-              if (sb.charAt(i) == ' ' || sb.charAt(i) == '\t' || sb.charAt(i) == comment_sl.charAt(0)) {
+            for (int i = 0; i < sb.length(); i++)
+            {
+              if (sb.charAt(i) == ' ' || sb.charAt(i) == '\t' || sb.charAt(i) == comment_sl.charAt(0))
+              {
                 count++;
-              } else {
+              }
+
+              else
+              {
                 break;
               }
             }
             sb.delete(0, count);
-          } else {
+          }
+          else
+          {
             sb.append(line);
           }
-        } else if (line.length() == 0 || isWhitespaces(line)) {
+        }
+        else if (line.length() == 0 || isWhitespaces(line))
+        {
           sb.append(line);
-        } else {
+        }
+        else
+        {
           sb.append(comment_sl).append(line);
         }
         sb.append("\n");
       }
 
-      if (!lastNewline) {
+      if (!lastNewline)
+      {
         sb.deleteCharAt(sb.length() - 1);
       }
 
@@ -546,7 +567,9 @@ public class LmnTextPane extends JTextPane
 
       setSelectionStart(new_start);
       setSelectionEnd(new_end);
-    } catch (BadLocationException e) {
+    }
+    catch (BadLocationException e)
+    {
       e.printStackTrace();
       return false;
     }


### PR DESCRIPTION
### 変更箇所
- 括弧とクオーテーションの自動補完
- コメントイン/アウトのショートカットの軽微な修正
  - コメントアウトの際に空白を挿入
  - `%` のコメントインを追加
  - コメントインの際に`//`または`%`以降に連続した空白やタブ文字の除去

### QA
- [x] ビルドが成功する
- [x] 括弧とクオーテーションが補完され、カーソルが正しい位置にある
- [x] ショートカットでコメントイン・アウトできる